### PR TITLE
tiny fix for tooltip usage inside a table

### DIFF
--- a/tlite.css
+++ b/tlite.css
@@ -17,6 +17,12 @@
   z-index: 1000;
 }
 
+/*needs to be place on the table tag when a td or th inside it contains a tooltip*/
+.tlite-table tr td,
+.tlite-table tr th {
+  position: relative;
+}
+
 .tlite-visible {
   visibility: visible;
   opacity: 0.9;


### PR DESCRIPTION
Without the relative position change, the tooltip on a `<td>` or `<th>` tag are rendered in the wrong position. A class .tlite-table on the containing `<table>` tag fixes the problem. Thanks to http://stackoverflow.com/users/5723569/head-in-cloud for pointing it out to me.